### PR TITLE
Run SetLocale after session middleware

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -11,7 +11,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->append(\App\Http\Middleware\SetLocale::class);
+        $middleware->appendToGroup('web', [
+            \App\Http\Middleware\SetLocale::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //


### PR DESCRIPTION
## Summary
- Ensure SetLocale middleware is appended to the web group so it runs after the session middleware

## Testing
- `composer test` *(fails: require vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9633151cc8331851d4a7e552074d4