### PR TITLE
Add language switcher to guest layout

### DIFF
--- a/resources/views/components/lang-switcher.blade.php
+++ b/resources/views/components/lang-switcher.blade.php
@@ -1,0 +1,4 @@
+<div class="flex space-x-2">
+    <a href="{{ route('lang.switch', 'en') }}" class="text-sm text-gray-500 hover:text-gray-700 px-2">{{ __('English') }}</a>
+    <a href="{{ route('lang.switch', 'el') }}" class="text-sm text-gray-500 hover:text-gray-700 px-2">{{ __('Greek') }}</a>
+</div>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -22,6 +22,8 @@
                 </a>
             </div>
 
+            <x-lang-switcher />
+
             <div class="w-full sm:max-w-md mt-6 px-6 py-4 bg-white shadow-md overflow-hidden sm:rounded-lg">
                 {{ $slot }}
             </div>


### PR DESCRIPTION
## Summary
- Add reusable `<x-lang-switcher>` component with English and Greek links
- Insert language switcher above guest content container so guest pages can switch locales

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: GitHub API 403 during package download)*

------
https://chatgpt.com/codex/tasks/task_e_68b973b1a1c48331b60e1691dc2adf0a