### PR TITLE
Add Greek translations for DataTables labels

### DIFF
--- a/resources/lang/el.json
+++ b/resources/lang/el.json
@@ -59,5 +59,10 @@
     "Last Name": "Επώνυμο",
     "No employees yet.": "Δεν υπάρχουν υπάλληλοι ακόμη.",
     "English": "Αγγλικά",
-    "Greek": "Ελληνικά"
+    "Greek": "Ελληνικά",
+    "Admin": "Διαχειριστής",
+    "Search": "Αναζήτηση",
+    "Showing _START_ to _END_ of _TOTAL_ entries": "Εμφάνιση _START_ έως _END_ από _TOTAL_ εγγραφές",
+    "Previous": "Προηγούμενο",
+    "Next": "Επόμενο"
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -59,5 +59,10 @@
     "Last Name": "Last Name",
     "No employees yet.": "No employees yet.",
     "English": "English",
-    "Greek": "Greek"
+    "Greek": "Greek",
+    "Admin": "Admin",
+    "Search": "Search",
+    "Showing _START_ to _END_ of _TOTAL_ entries": "Showing _START_ to _END_ of _TOTAL_ entries",
+    "Previous": "Previous",
+    "Next": "Next"
 }

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -58,7 +58,15 @@
                     order: [[0, 'asc']],     // sort by Name
                     columnDefs: [
                     { targets: [3, 4], orderable: false, searchable: false } // Logo, Actions
-                    ]
+                    ],
+                    language: {
+                    search: "{{ __('Search') }}:",
+                    info: "{{ __('Showing _START_ to _END_ of _TOTAL_ entries') }}",
+                    paginate: {
+                        previous: "{{ __('Previous') }}",
+                        next: "{{ __('Next') }}"
+                    }
+                    }
                 });
                 }
 
@@ -69,7 +77,15 @@
                     order: [[1, 'asc']],     // sort by Last Name
                     columnDefs: [
                     { targets: [5], orderable: false, searchable: false }    // Actions
-                    ]
+                    ],
+                    language: {
+                    search: "{{ __('Search') }}:",
+                    info: "{{ __('Showing _START_ to _END_ of _TOTAL_ entries') }}",
+                    paginate: {
+                        previous: "{{ __('Previous') }}",
+                        next: "{{ __('Next') }}"
+                    }
+                    }
                 });
                 }
             });


### PR DESCRIPTION
## Summary
- Translate DataTables search, info and pagination text into Greek
- Add "Admin" translation entry

## Testing
- ⚠️ `php artisan test` *(failed: Missing vendor dependencies and composer requires GitHub authentication)*
- ⚠️ `npm test` *(failed: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b9773882e08331a843bf0e6089c8f9