### PR TITLE
Integrate AdminLTE layout

### DIFF
--- a/resources/lang/el.json
+++ b/resources/lang/el.json
@@ -58,6 +58,7 @@
     "First Name": "Όνομα",
     "Last Name": "Επώνυμο",
     "No employees yet.": "Δεν υπάρχουν υπάλληλοι ακόμη.",
+    "Language": "Γλώσσα",
     "English": "Αγγλικά",
     "Greek": "Ελληνικά",
     "Admin": "Διαχειριστής",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -58,6 +58,7 @@
     "First Name": "First Name",
     "Last Name": "Last Name",
     "No employees yet.": "No employees yet.",
+    "Language": "Language",
     "English": "English",
     "Greek": "Greek",
     "Admin": "Admin",

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -11,86 +11,92 @@
         <link rel="preconnect" href="https://fonts.bunny.net">
         <link href="https://fonts.bunny.net/css?family=figtree:400,500,600&display=swap" rel="stylesheet" />
 
+        <!-- Font Awesome -->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@5.15.4/css/all.min.css">
+        <!-- AdminLTE -->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/css/adminlte.min.css">
         <!-- DataTables CSS -->
         <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/jquery.dataTables.min.css">
 
         <!-- Scripts -->
         @vite(['resources/css/app.css', 'resources/js/app.js'])
     </head>
-    <body class="font-sans antialiased">
-        <div class="min-h-screen bg-gray-100">
+    <body class="hold-transition sidebar-mini">
+        <div class="wrapper">
             @include('layouts.navigation')
+            @include('layouts.sidebar')
 
-            <!-- Page Heading -->
-            @isset($header)
-                <header class="bg-white shadow">
-                    <div class="max-w-7xl mx-auto py-6 px-4 sm:px-6 lg:px-8">
-                        {{ $header }}
+            <!-- Content Wrapper. Contains page content -->
+            <div class="content-wrapper">
+                @isset($header)
+                    <section class="content-header">
+                        <div class="container-fluid">
+                            {{ $header }}
+                        </div>
+                    </section>
+                @endisset
+
+                <!-- Flash Messages -->
+                @if (session('status'))
+                    <div class="container-fluid">
+                        <div class="alert alert-success">
+                            {{ session('status') }}
+                        </div>
                     </div>
-                </header>
-            @endisset
+                @endif
 
-            <!-- Flash Messages -->
-            @if (session('status'))
-                <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 mt-4">
-                    <div class="bg-green-50 border border-green-200 text-green-700 px-4 py-2 rounded">
-                        {{ session('status') }}
-                    </div>
-                </div>
-            @endif
-
-            <!-- Page Content -->
-            <main>
-                {{ $slot }}
-            </main>
+                <!-- Main content -->
+                <section class="content">
+                    {{ $slot }}
+                </section>
+            </div>
         </div>
 
-        <!-- jQuery + DataTables JS -->
-        <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+        <!-- Scripts -->
+        <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.4/dist/jquery.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/npm/admin-lte@3.2/dist/js/adminlte.min.js"></script>
         <script src="https://cdn.datatables.net/1.13.6/js/jquery.dataTables.min.js"></script>
-
         <script>
             $(function () {
                 if ($('#companies-table').length) {
-                $('#companies-table').DataTable({
-                    dom: 'frtip',            // hide length menu (no "l")
-                    pageLength: 10,
-                    order: [[0, 'asc']],     // sort by Name
-                    columnDefs: [
-                    { targets: [3, 4], orderable: false, searchable: false } // Logo, Actions
-                    ],
-                    language: {
-                    search: "{{ __('Search') }}:",
-                    info: "{{ __('Showing _START_ to _END_ of _TOTAL_ entries') }}",
-                    paginate: {
-                        previous: "{{ __('Previous') }}",
-                        next: "{{ __('Next') }}"
-                    }
-                    }
-                });
+                    $('#companies-table').DataTable({
+                        dom: 'frtip',            // hide length menu (no "l")
+                        pageLength: 10,
+                        order: [[0, 'asc']],     // sort by Name
+                        columnDefs: [
+                            { targets: [3, 4], orderable: false, searchable: false } // Logo, Actions
+                        ],
+                        language: {
+                            search: "{{ __('Search') }}:",
+                            info: "{{ __('Showing _START_ to _END_ of _TOTAL_ entries') }}",
+                            paginate: {
+                                previous: "{{ __('Previous') }}",
+                                next: "{{ __('Next') }}"
+                            }
+                        }
+                    });
                 }
 
                 if ($('#employees-table').length) {
-                $('#employees-table').DataTable({
-                    dom: 'frtip',            // hide length menu
-                    pageLength: 10,
-                    order: [[1, 'asc']],     // sort by Last Name
-                    columnDefs: [
-                    { targets: [5], orderable: false, searchable: false }    // Actions
-                    ],
-                    language: {
-                    search: "{{ __('Search') }}:",
-                    info: "{{ __('Showing _START_ to _END_ of _TOTAL_ entries') }}",
-                    paginate: {
-                        previous: "{{ __('Previous') }}",
-                        next: "{{ __('Next') }}"
-                    }
-                    }
-                });
+                    $('#employees-table').DataTable({
+                        dom: 'frtip',            // hide length menu
+                        pageLength: 10,
+                        order: [[1, 'asc']],     // sort by Last Name
+                        columnDefs: [
+                            { targets: [5], orderable: false, searchable: false }    // Actions
+                        ],
+                        language: {
+                            search: "{{ __('Search') }}:",
+                            info: "{{ __('Showing _START_ to _END_ of _TOTAL_ entries') }}",
+                            paginate: {
+                                previous: "{{ __('Previous') }}",
+                                next: "{{ __('Next') }}"
+                            }
+                        }
+                    });
                 }
             });
-            </script>
-
-
+        </script>
     </body>
 </html>

--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -1,126 +1,45 @@
-<nav x-data="{ open: false }" class="bg-white border-b border-gray-100">
-    <!-- Primary Navigation Menu -->
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div class="flex justify-between h-16">
-            <div class="flex">
-                <!-- Logo -->
-                <div class="shrink-0 flex items-center">
-                    <a href="{{ route('dashboard') }}">
-                        <x-application-logo class="block h-9 w-auto fill-current text-gray-800" />
-                    </a>
-                </div>
+<nav class="main-header navbar navbar-expand navbar-white navbar-light">
+    <!-- Left navbar links -->
+    <ul class="navbar-nav">
+        <li class="nav-item">
+            <a class="nav-link" data-widget="pushmenu" href="#" role="button"><i class="fas fa-bars"></i></a>
+        </li>
+        <li class="nav-item d-none d-sm-inline-block">
+            <a href="{{ route('companies.index') }}" class="nav-link">{{ __('Companies') }}</a>
+        </li>
+        <li class="nav-item d-none d-sm-inline-block">
+            <a href="{{ route('employees.index') }}" class="nav-link">{{ __('Employees') }}</a>
+        </li>
+    </ul>
 
-                <!-- Navigation Links -->
-                <div class="hidden space-x-8 sm:-my-px sm:ms-10 sm:flex">
-                    <!-- <x-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                        {{ __('Dashboard') }}
-                    </x-nav-link> -->
-
-                    <x-nav-link :href="route('companies.index')" :active="request()->routeIs('companies.*')">
-                        {{ __('Companies') }}
-                    </x-nav-link>
-
-                    <x-nav-link :href="route('employees.index')" :active="request()->routeIs('employees.*')">
-                        {{ __('Employees') }}
-                    </x-nav-link>
-                </div>
+    <!-- Right navbar links -->
+    <ul class="navbar-nav ml-auto">
+        <li class="nav-item dropdown">
+            <a class="nav-link" data-toggle="dropdown" href="#" role="button">
+                {{ __('Language') }}
+            </a>
+            <div class="dropdown-menu dropdown-menu-right">
+                <a href="{{ route('lang.switch', 'en') }}" class="dropdown-item">{{ __('English') }}</a>
+                <a href="{{ route('lang.switch', 'el') }}" class="dropdown-item">{{ __('Greek') }}</a>
             </div>
+        </li>
 
-            <div class="hidden sm:flex sm:items-center sm:ms-6">
-                <a href="{{ route('lang.switch', 'en') }}" class="text-sm text-gray-500 hover:text-gray-700 px-2">{{ __('English') }}</a>
-                <a href="{{ route('lang.switch', 'el') }}" class="text-sm text-gray-500 hover:text-gray-700 px-2">{{ __('Greek') }}</a>
-            </div>
-
-            <!-- Settings Dropdown -->
-            <div class="hidden sm:flex sm:items-center sm:ms-6">
-                <x-dropdown align="right" width="48">
-                    <x-slot name="trigger">
-                        <button class="inline-flex items-center px-3 py-2 border border-transparent text-sm leading-4 font-medium rounded-md text-gray-500 bg-white hover:text-gray-700 focus:outline-none transition ease-in-out duration-150">
-                            <div>{{ Auth::user()->name }}</div>
-
-                            <div class="ms-1">
-                                <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-                                    <path fill-rule="evenodd" d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" clip-rule="evenodd" />
-                                </svg>
-                            </div>
-                        </button>
-                    </x-slot>
-
-                    <x-slot name="content">
-                        <x-dropdown-link :href="route('profile.edit')">
-                            {{ __('Profile') }}
-                        </x-dropdown-link>
-
-                        <!-- Authentication -->
-                        <form method="POST" action="{{ route('logout') }}">
-                            @csrf
-                            <x-dropdown-link :href="route('logout')"
-                                onclick="event.preventDefault(); this.closest('form').submit();">
-                                {{ __('Log Out') }}
-                            </x-dropdown-link>
-                        </form>
-                    </x-slot>
-                </x-dropdown>
-            </div>
-
-            <!-- Hamburger -->
-            <div class="-me-2 flex items-center sm:hidden">
-                <button @click="open = ! open" class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 hover:text-gray-500 hover:bg-gray-100 focus:outline-none focus:bg-gray-100 focus:text-gray-500 transition duration-150 ease-in-out">
-                    <svg class="h-6 w-6" stroke="currentColor" fill="none" viewBox="0 0 24 24">
-                        <path :class="{'hidden': open, 'inline-flex': ! open }" class="inline-flex" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
-                        <path :class="{'hidden': ! open, 'inline-flex': open }" class="hidden" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                    </svg>
-                </button>
-            </div>
-        </div>
-    </div>
-
-    <!-- Responsive Navigation Menu -->
-    <div :class="{'block': open, 'hidden': ! open}" class="hidden sm:hidden">
-        <div class="pt-2 pb-3 space-y-1">
-            <!-- <x-responsive-nav-link :href="route('dashboard')" :active="request()->routeIs('dashboard')">
-                {{ __('Dashboard') }}
-            </x-responsive-nav-link> -->
-
-            <x-responsive-nav-link :href="route('companies.index')" :active="request()->routeIs('companies.*')">
-                {{ __('Companies') }}
-            </x-responsive-nav-link>
-
-            <x-responsive-nav-link :href="route('employees.index')" :active="request()->routeIs('employees.*')">
-                {{ __('Employees') }}
-            </x-responsive-nav-link>
-        </div>
-
-        <div class="pt-2 pb-3 border-t border-gray-200 space-y-1">
-            <x-responsive-nav-link :href="route('lang.switch', 'en')">
-                {{ __('English') }}
-            </x-responsive-nav-link>
-            <x-responsive-nav-link :href="route('lang.switch', 'el')">
-                {{ __('Greek') }}
-            </x-responsive-nav-link>
-        </div>
-
-        <!-- Responsive Settings Options -->
-        <div class="pt-4 pb-1 border-t border-gray-200">
-            <div class="px-4">
-                <div class="font-medium text-base text-gray-800">{{ Auth::user()->name }}</div>
-                <div class="font-medium text-sm text-gray-500">{{ Auth::user()->email }}</div>
-            </div>
-
-            <div class="mt-3 space-y-1">
-                <x-responsive-nav-link :href="route('profile.edit')">
-                    {{ __('Profile') }}
-                </x-responsive-nav-link>
-
-                <!-- Authentication -->
+        <li class="nav-item dropdown">
+            <a class="nav-link" data-toggle="dropdown" href="#" role="button">
+                <span class="d-inline-flex align-items-center justify-content-center bg-secondary rounded-circle text-white" style="width: 35px; height: 35px;">
+                    {{ strtoupper(substr(Auth::user()->name, 0, 1)) }}
+                </span>
+            </a>
+            <div class="dropdown-menu dropdown-menu-right">
+                <span class="dropdown-item-text">{{ Auth::user()->name }}</span>
+                <div class="dropdown-divider"></div>
+                <a href="{{ route('profile.edit') }}" class="dropdown-item">{{ __('Profile') }}</a>
+                <div class="dropdown-divider"></div>
                 <form method="POST" action="{{ route('logout') }}">
                     @csrf
-                    <x-responsive-nav-link :href="route('logout')"
-                        onclick="event.preventDefault(); this.closest('form').submit();">
-                        {{ __('Log Out') }}
-                    </x-responsive-nav-link>
+                    <button type="submit" class="dropdown-item">{{ __('Log Out') }}</button>
                 </form>
             </div>
-        </div>
-    </div>
+        </li>
+    </ul>
 </nav>

--- a/resources/views/layouts/sidebar.blade.php
+++ b/resources/views/layouts/sidebar.blade.php
@@ -1,0 +1,27 @@
+<aside class="main-sidebar sidebar-dark-primary elevation-4">
+    <!-- Brand Logo -->
+    <a href="{{ route('companies.index') }}" class="brand-link">
+        <span class="brand-text font-weight-light">{{ config('app.name') }}</span>
+    </a>
+
+    <!-- Sidebar -->
+    <div class="sidebar">
+        <!-- Sidebar Menu -->
+        <nav class="mt-2">
+            <ul class="nav nav-pills nav-sidebar flex-column" role="menu">
+                <li class="nav-item">
+                    <a href="{{ route('companies.index') }}" class="nav-link {{ request()->routeIs('companies.*') ? 'active' : '' }}">
+                        <i class="nav-icon fas fa-building"></i>
+                        <p>{{ __('Companies') }}</p>
+                    </a>
+                </li>
+                <li class="nav-item">
+                    <a href="{{ route('employees.index') }}" class="nav-link {{ request()->routeIs('employees.*') ? 'active' : '' }}">
+                        <i class="nav-icon fas fa-users"></i>
+                        <p>{{ __('Employees') }}</p>
+                    </a>
+                </li>
+            </ul>
+        </nav>
+    </div>
+</aside>


### PR DESCRIPTION
## Summary
- group language options under a dedicated dropdown
- display user menu as a round icon and remove dashboard link
- translate new language label

## Testing
- `npm run build`
- `php artisan test` *(fails: require vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68b97e9f7868833180cbd33d6687f9ed