### PR TITLE
Remove top nav links for company and employee sections

### DIFF
--- a/resources/views/layouts/navigation.blade.php
+++ b/resources/views/layouts/navigation.blade.php
@@ -16,13 +16,17 @@
                         {{ __('Dashboard') }}
                     </x-nav-link> -->
 
+                    <!--
                     <x-nav-link :href="route('companies.index')" :active="request()->routeIs('companies.*')">
                         {{ __('Companies') }}
                     </x-nav-link>
+                    -->
 
+                    <!--
                     <x-nav-link :href="route('employees.index')" :active="request()->routeIs('employees.*')">
                         {{ __('Employees') }}
                     </x-nav-link>
+                    -->
                 </div>
             </div>
 
@@ -77,13 +81,17 @@
                 {{ __('Dashboard') }}
             </x-responsive-nav-link> -->
 
+            <!--
             <x-responsive-nav-link :href="route('companies.index')" :active="request()->routeIs('companies.*')">
                 {{ __('Companies') }}
             </x-responsive-nav-link>
+            -->
 
+            <!--
             <x-responsive-nav-link :href="route('employees.index')" :active="request()->routeIs('employees.*')">
                 {{ __('Employees') }}
             </x-responsive-nav-link>
+            -->
         </div>
 
         <!-- Responsive Settings Options -->


### PR DESCRIPTION
## Summary
- hide Companies and Employees links from primary navigation
- hide Companies and Employees links from responsive navigation

## Testing
- `composer test` *(fails: vendor/autoload.php missing)*
- `composer install` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68b98cd12b0883319c112e7bb75c52a6